### PR TITLE
allow to change i2c address

### DIFF
--- a/adafruit_sht4x.py
+++ b/adafruit_sht4x.py
@@ -90,8 +90,8 @@ class SHT4x:
 
     """
 
-    def __init__(self, i2c_bus, i2c_addr=_SHT4X_DEFAULT_ADDR):
-        self.i2c_device = i2c_device.I2CDevice(i2c_bus, i2c_addr)
+    def __init__(self, i2c_bus, address=_SHT4X_DEFAULT_ADDR):
+        self.i2c_device = i2c_device.I2CDevice(i2c_bus, address)
         self._buffer = bytearray(6)
         self.reset()
         self._mode = Mode.NOHEAT_HIGHPRECISION  # pylint: disable=no-member

--- a/adafruit_sht4x.py
+++ b/adafruit_sht4x.py
@@ -90,8 +90,8 @@ class SHT4x:
 
     """
 
-    def __init__(self, i2c_bus):
-        self.i2c_device = i2c_device.I2CDevice(i2c_bus, _SHT4X_DEFAULT_ADDR)
+    def __init__(self, i2c_bus, i2c_addr=_SHT4X_DEFAULT_ADDR):
+        self.i2c_device = i2c_device.I2CDevice(i2c_bus, i2c_addr)
         self._buffer = bytearray(6)
         self.reset()
         self._mode = Mode.NOHEAT_HIGHPRECISION  # pylint: disable=no-member


### PR DESCRIPTION
Hello, like bme280
https://github.com/adafruit/Adafruit_CircuitPython_BME280/blob/287979991b5b69f01315bf17e18fddeb48cc6b3b/adafruit_bme280.py#L470
it would be greate to allow changing i2c address when instance is created.
